### PR TITLE
fixes player one rod two movement

### DIFF
--- a/foosball_table.svg
+++ b/foosball_table.svg
@@ -670,7 +670,7 @@
        sodipodi:nodetypes="ccccc" />
     <rect
        style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:11.33899975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="P2_1_move_away-38"
+       id="P1_2_move_away"
        width="15"
        height="40"
        x="377.52817"


### PR DESCRIPTION
Rod two (red side) can not be moved away from the players side. The issue is a wrong id in foosball_table.svg.  